### PR TITLE
Adapted to GHC 8.2.1

### DIFF
--- a/utils/GHC/SYB/Utils.hs
+++ b/utils/GHC/SYB/Utils.hs
@@ -185,7 +185,9 @@ import qualified OccName(occNameString)
 import Bag(Bag,bagToList)
 import Var(Var)
 import FastString(FastString)
-#if __GLASGOW_HASKELL__ >= 709
+#if __GLASGOW_HASKELL__ >= 800
+import NameSet(NameSet,nameSetElemsStable)
+#elif __GLASGOW_HASKELL__ >= 709
 import NameSet(NameSet,nameSetElems)
 #else
 import NameSet(NameSet,nameSetToList)
@@ -198,7 +200,10 @@ import GHC.SYB.Instances
 import Control.Monad
 import Data.List
 
-#if __GLASGOW_HASKELL__ < 709
+#if __GLASGOW_HASKELL__ >= 800
+nameSetElems :: NameSet -> [Name]
+nameSetElems = nameSetElemsStable
+#elif __GLASGOW_HASKELL__ < 709
 nameSetElems :: NameSet -> [Name]
 nameSetElems = nameSetToList
 #endif

--- a/utils/ghc-syb-utils.cabal
+++ b/utils/ghc-syb-utils.cabal
@@ -1,5 +1,5 @@
 name:            ghc-syb-utils
-version:         0.2.3
+version:         0.2.3.1
 license:         BSD3
 license-file:    LICENSE
 author:          Claus Reinke


### PR DESCRIPTION
GHC 8.2.1 is now in release candidate state.
There are few changes in API, requiring a minor adaptation on `ghc-syb-utils` side:
`nameSetElems` is removed in favor of `nameSetElemsStable` in module `NameSet`.

